### PR TITLE
Type annotations an minor cleanup for utilities

### DIFF
--- a/openavmkit/utilities/assertions.py
+++ b/openavmkit/utilities/assertions.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from openavmkit.utilities.timing import TimingData
 
-def objects_are_equal(a, b, epsilon: float = 1e-6):
+def objects_are_equal(a, b, epsilon: float = 1e-6) -> bool:
     """Test whether two objects are equal
 
     Checks strings, dicts, lists, ints, floats, and objects
@@ -73,7 +73,7 @@ def objects_are_equal(a, b, epsilon: float = 1e-6):
         return a == b
 
 
-def lists_are_equal(a: list, b: list):
+def lists_are_equal(a: list, b: list) -> bool:
     """Test whether two lists are equal
 
     Parameters
@@ -105,7 +105,7 @@ def lists_are_equal(a: list, b: list):
     return True
 
 
-def dicts_are_equal(a: dict, b: dict):
+def dicts_are_equal(a: dict, b: dict) -> bool:
     """Test whether two dictionaries are equal
 
     Parameters
@@ -133,7 +133,7 @@ def dicts_are_equal(a: dict, b: dict):
     return True
 
 
-def dfs_are_equal(a: pd.DataFrame, b: pd.DataFrame, primary_key=None, allow_weak=False):
+def dfs_are_equal(a: pd.DataFrame, b: pd.DataFrame, primary_key=None, allow_weak=False) -> bool:
     """Test whether two DataFrames are equal
 
     Parameters
@@ -259,7 +259,7 @@ def dfs_are_equal(a: pd.DataFrame, b: pd.DataFrame, primary_key=None, allow_weak
 
 
 
-def series_are_equal(a: pd.Series, b: pd.Series):
+def series_are_equal(a: pd.Series, b: pd.Series) -> bool:
     """Test whether two series are equal
 
     Parameters

--- a/openavmkit/utilities/cache.py
+++ b/openavmkit/utilities/cache.py
@@ -18,7 +18,7 @@ def write_cache(
     payload: dict | str | pd.DataFrame | gpd.GeoDataFrame | bytes,
     signature: dict | str,
     filetype: str,
-):
+) -> None:
     """Caches the data to disk
 
     Parameters
@@ -74,7 +74,7 @@ def write_cache(
             file.write(signature)
 
 
-def read_cache(filename: str, filetype: str):
+def read_cache(filename: str, filetype: str) -> dict | str | object | pd.DataFrame | gpd.GeoDataFrame | None:
     """Reads cached data from disk
 
     Parameters
@@ -113,7 +113,7 @@ def read_cache(filename: str, filetype: str):
     return None
 
 
-def check_cache(filename: str, signature: dict | str, filetype: str):
+def check_cache(filename: str, signature: dict | str, filetype: str) -> bool:
     """Check if the cached data exists and if the signatures match
 
     Parameters
@@ -139,7 +139,7 @@ def check_cache(filename: str, signature: dict | str, filetype: str):
     return False
 
 
-def clear_cache(filename: str, filetype: str):
+def clear_cache(filename: str, filetype: str) -> None:
     """Clear the specified cache data
 
     Parameters
@@ -446,7 +446,7 @@ def _get_model_group_signature(df: pd.DataFrame)->dict:
     return {}
 
 
-def _get_df_signature(df: pd.DataFrame, extra: dict | str = None):
+def _get_df_signature(df: pd.DataFrame, extra: dict | str = None) -> dict:
     sorted_columns = sorted(df.columns)
     signature = {
         "num_rows": len(df),
@@ -480,7 +480,7 @@ def _match_signature(filename: str, signature: dict | str) -> bool:
     return match
 
 
-def _get_extension(filetype: str):
+def _get_extension(filetype: str) -> str:
     if filetype == "dict":
         return "json"
     elif filetype == "str":

--- a/openavmkit/utilities/clustering.py
+++ b/openavmkit/utilities/clustering.py
@@ -1,5 +1,8 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
+
+from typing import Tuple
+
 from openavmkit.utilities.timing import TimingData
 
 
@@ -13,7 +16,7 @@ def make_clusters(
     verbose: bool = False,
     output_folder: str = "",
     t: TimingData = None
-):
+) -> Tuple[pd.Series, list[str], pd.Series]:
     """
     Partition a DataFrame into hierarchical clusters based on location, vacancy,
     categorical, and numeric fields.

--- a/openavmkit/utilities/data.py
+++ b/openavmkit/utilities/data.py
@@ -1,10 +1,11 @@
 import os
 import pickle
 
-import numpy as np
-import pandas as pd
 import geopandas as gpd
+import numpy as np
 import osmnx as ox
+import pandas as pd
+
 from collections import defaultdict
 
 from scipy.spatial._ckdtree import cKDTree
@@ -12,7 +13,7 @@ from scipy.spatial._ckdtree import cKDTree
 from openavmkit.utilities.settings import get_model_group_ids
 
 
-def is_column_of_type(df: pd.DataFrame, col: str, type_name: str):
+def is_column_of_type(df: pd.DataFrame, col: str, type_name: str) -> bool:
     series = df[col]
     if type_name == "str" or type_name == "string":
         return (
@@ -41,7 +42,7 @@ def is_column_of_type(df: pd.DataFrame, col: str, type_name: str):
         raise ValueError("Unknown type name: {type_name}")
 
 
-def clean_column_names(df: pd.DataFrame):
+def clean_column_names(df: pd.DataFrame) -> pd.DataFrame:
     """Clean the column names in a DataFrame by replacing forbidden characters with legal
     representations. For one-hot encoded columns (containing '='), ensures clean formatting.
 
@@ -105,7 +106,7 @@ def clean_column_names(df: pd.DataFrame):
     return df
 
 
-def clean_series(series: pd.Series):
+def clean_series(series: pd.Series) -> pd.Series:
     """Clean the values in a Series by replacing forbidden characters with legal representations.
 
     Parameters
@@ -141,7 +142,7 @@ def clean_series(series: pd.Series):
 
 def div_series_z_safe(
     numerator: pd.Series | np.ndarray, denominator: pd.Series | np.ndarray
-):
+) -> pd.Series | np.ndarray:
     """Perform a divide-by-zero-safe division of two series or arrays, replacing division
     by zero with None.
 
@@ -193,7 +194,7 @@ def div_series_z_safe(
     raise ValueError(f"Can only operate on Series-like objects or np.ndarray, found: {type(numerator), type(denominator)}")
 
 
-def div_df_z_safe(df: pd.DataFrame, numerator: str, denominator: str):
+def div_df_z_safe(df: pd.DataFrame, numerator: str, denominator: str) -> pd.Series:
     """Perform a divide-by-zero-safe division of two columns in a DataFrame, replacing
     division by zero with None.
 
@@ -232,7 +233,7 @@ def div_df_z_safe(df: pd.DataFrame, numerator: str, denominator: str):
     return result
 
 
-def df_to_markdown(df: pd.DataFrame):
+def df_to_markdown(df: pd.DataFrame) -> str:
     """Convert a DataFrame to a markdown-formatted string.
 
     Parameters
@@ -251,12 +252,12 @@ def df_to_markdown(df: pd.DataFrame):
     return f"{header}\n{separator}\n{rows}"
 
 
-def rename_dict(dict, renames):
+def rename_dict(original_dict: dict, renames:dict) -> dict:
     """Rename the keys of a dictionary according to a given rename map.
 
     Parameters
     ----------
-    dict : Dictionary
+    original_dict : Dictionary
         Original dictionary.
 
     renames : Dictionary
@@ -267,9 +268,9 @@ def rename_dict(dict, renames):
     New dictionary with keys renamed
     """
     new_dict = {}
-    for key in dict:
+    for key in original_dict:
         new_key = renames.get(key, key)
-        new_dict[new_key] = dict[key]
+        new_dict[new_key] = original_dict[key]
     return new_dict
 
 
@@ -527,7 +528,7 @@ def combine_dfs(
     return df
 
 
-def add_sqft_fields(df_in: pd.DataFrame):
+def add_sqft_fields(df_in: pd.DataFrame) -> pd.DataFrame:
     """Add per-square-foot fields to the DataFrame for land and improvement values.
 
     This function creates new columns based on existing value fields and area fields.
@@ -570,7 +571,7 @@ def add_sqft_fields(df_in: pd.DataFrame):
 
 def count_values_in_common(
     a: pd.DataFrame, b: pd.DataFrame, a_field: str, b_field: str = None
-):
+) -> tuple[int, int]:
     """Count all the unique values that two columns of two dataframes have in common
 
     Parameters
@@ -841,7 +842,7 @@ def load_model_results(
     model_name: str,
     subset: str = "universe",
     model_type: str = "main",
-):
+) -> pd.DataFrame | None:
     """
     Load model prediction results for a specified subset from disk, if available.
 

--- a/openavmkit/utilities/excel.py
+++ b/openavmkit/utilities/excel.py
@@ -4,7 +4,7 @@ from xlsxwriter.format import Format
 from xlsxwriter.worksheet import Worksheet
 
 
-def write_to_excel(df: pd.DataFrame, path: str, metadata: dict):
+def write_to_excel(df: pd.DataFrame, path: str, metadata: dict) -> None:
     """
     Write a DataFrame to an Excel file with custom column formats and conditional formatting.
 
@@ -115,7 +115,7 @@ def write_to_excel(df: pd.DataFrame, path: str, metadata: dict):
             worksheet.conditional_format(1, col_idx, len(df), col_idx, condition)
 
 
-def _clean_formats(formats: dict):
+def _clean_formats(formats: dict) -> dict:
     replaces = {"$": "_dollar_", "%": "_percent_"}
     new_keys = {}
     for key in formats:

--- a/openavmkit/utilities/format.py
+++ b/openavmkit/utilities/format.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 
-def dig2_fancy_format(num):
+def dig2_fancy_format(num: float | int) -> str:
     """Fancy-formats a number, and if the absolute value of the number is less than 100, shows it with two digits
 
     Parameters
@@ -23,7 +23,7 @@ def dig2_fancy_format(num):
         return fancy_format(num)
 
 
-def fancy_format(num):
+def fancy_format(num: float | int) -> str:
     """Formats a number in a pleasing and efficient way
 
     Parameters

--- a/openavmkit/utilities/geometry.py
+++ b/openavmkit/utilities/geometry.py
@@ -5,6 +5,7 @@ import warnings
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pyproj
 import shapely
 import json
 
@@ -27,7 +28,7 @@ CRS84_ALIASES = {
     "HTTPS://WWW.OPENGIS.NET/DEF/CRS/OGC/1.3/CRS84",
 }
 
-def get_crs(gdf, projection_type):
+def get_crs(gdf: gpd.GeoDataFrame, projection_type: str) -> pyproj.CRS:
     """Returns the appropriate CRS for a GeoDataFrame based on the specified projection
     type.
 
@@ -59,7 +60,7 @@ def get_crs(gdf, projection_type):
 
 def get_crs_from_lat_lon(
     lat: float, lon: float, projection_type: str, units: str = "m"
-):
+) -> pyproj.CRS:
     """Return a Coordinate Reference System (CRS) suitable for the requested projection type at the given
     latitude/longitude location.
 
@@ -168,7 +169,7 @@ def safe_normalize_to_4326(crs):
         return False
 
 
-def offset_coordinate_feet(lat, lon, lat_feet, lon_feet) -> (float, float):
+def offset_coordinate_feet(lat: float, lon: float, lat_feet: float, lon_feet: float) -> tuple[float, float]:
     """Offset a lat/long coordinate by the designated number of feet
 
     Parameters
@@ -192,7 +193,7 @@ def offset_coordinate_feet(lat, lon, lat_feet, lon_feet) -> (float, float):
     return offset_coordinate_km(lat, lon, lat_km, lon_km)
 
 
-def offset_coordinate_miles(lat, lon, lat_miles, lon_miles) -> (float, float):
+def offset_coordinate_miles(lat, lon, lat_miles, lon_miles) -> tuple[float, float]:
     """Offset a lat/long coordinate by the designated number of miles
 
     Parameters
@@ -216,7 +217,7 @@ def offset_coordinate_miles(lat, lon, lat_miles, lon_miles) -> (float, float):
     return offset_coordinate_km(lat, lon, lat_km, lon_km)
 
 
-def offset_coordinate_m(lat, lon, lat_m, lon_m) -> (float, float):
+def offset_coordinate_m(lat: float, lon: float, lat_m: float, lon_m: float) -> tuple[float, float]:
     """Offset a lat/long coordinate by the designated number of meters
 
     Parameters
@@ -241,7 +242,7 @@ def offset_coordinate_m(lat, lon, lat_m, lon_m) -> (float, float):
 
 
 
-def offset_coordinate_km(lat, lon, lat_km, lon_km):
+def offset_coordinate_km(lat: float, lon: float, lat_km: float, lon_km: float) -> tuple[float, float]:
   # shift north/south
   lon_ns, lat_ns, _ = geod.fwd(
     lon, lat,
@@ -263,7 +264,7 @@ def offset_coordinate_km(lat, lon, lat_km, lon_km):
 
 
 
-def distance_km(lat1, lon1, lat2, lon2):
+def distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
   """
   Calculates the distance in kilometers between two latitude/longitude points.
   :param lat1: Latitude of the first point.
@@ -277,7 +278,7 @@ def distance_km(lat1, lon1, lat2, lon2):
 
 
 
-def create_geo_circle(lat, lon, crs, radius_km, num_points=100):
+def create_geo_circle(lat: float, lon: float, crs: pyproj.CRS, radius_km: float, num_points: int=100) -> gpd.GeoDataFrame:
     """Creates a GeoDataFrame containing a circle centered at the specified latitude and
     longitude.
 
@@ -316,7 +317,7 @@ def create_geo_circle(lat, lon, crs, radius_km, num_points=100):
     return gdf
 
 
-def create_geo_rect_shape_deg(lat, lon, width_deg, height_deg, anchor_point="center"):
+def create_geo_rect_shape_deg(lat: float, lon: float, width_deg: float, height_deg: float, anchor_point: str="center") -> Polygon:
     """Creates a GeoDataFrame containing a rectangle centered at the specified latitude
     and longitude.
 
@@ -335,8 +336,8 @@ def create_geo_rect_shape_deg(lat, lon, width_deg, height_deg, anchor_point="cen
 
     Returns
     -------
-    gpd.GeoDataFrame
-        A GeoDataFrame containing the rectangle.
+    Polygon
+        A shapely Polygon object representing the rectangle.
     """
 
     if anchor_point == "center":
@@ -386,7 +387,7 @@ def create_geo_rect_shape_deg(lat, lon, width_deg, height_deg, anchor_point="cen
     return polygon
 
 
-def create_geo_rect_shape_km(lat, lon, width_km, height_km, anchor_point="center"):
+def create_geo_rect_shape_km(lat: float, lon: float, width_km: float, height_km: float, anchor_point: str="center") -> Polygon:
     """Creates a GeoDataFrame containing a rectangle centered at the specified latitude
     and longitude.
 
@@ -405,8 +406,8 @@ def create_geo_rect_shape_km(lat, lon, width_km, height_km, anchor_point="center
 
     Returns
     -------
-    gpd.GeoDataFrame
-        A GeoDataFrame containing the rectangle.
+    Polygon
+        A polygon representing a rectangle.
     """
 
     if anchor_point == "center":
@@ -456,7 +457,7 @@ def create_geo_rect_shape_km(lat, lon, width_km, height_km, anchor_point="center
     return polygon
 
 
-def create_geo_rect(lat, lon, crs, width_km, height_km, anchor_point="center"):
+def create_geo_rect(lat: float, lon: float, crs: pyproj.CRS, width_km: float, height_km: float, anchor_point: str="center") -> gpd.GeoDataFrame:
     """Creates a GeoDataFrame containing a rectangle centered at the specified latitude
     and longitude.
 
@@ -491,7 +492,7 @@ def create_geo_rect(lat, lon, crs, width_km, height_km, anchor_point="center"):
     return gdf
 
 
-def ensure_geometries(df, geom_col="geometry", crs=None):
+def ensure_geometries(df: pd.DataFrame, geom_col: str="geometry", crs: pyproj.CRS=None) -> gpd.GeoDataFrame:
     """Parse a DataFrame whose `geom_col` may be:
 
       - Shapely geometries
@@ -583,7 +584,7 @@ def ensure_geometries(df, geom_col="geometry", crs=None):
     return gpd.GeoDataFrame(df_clean, geometry=geom_series, crs=crs)
 
 
-def clean_geometry(gdf, ensure_polygon=True, target_crs=None):
+def clean_geometry(gdf: gpd.GeoDataFrame, ensure_polygon: bool=True, target_crs: str|int=None):
     """Preprocess a GeoDataFrame by diagnosing and fixing common geometry issues.
 
     Parameters
@@ -650,8 +651,8 @@ def clean_geometry(gdf, ensure_polygon=True, target_crs=None):
 
 
 def detect_triangular_lots(
-    geom, compactness_threshold=0.85, angle_tolerance=10, min_aspect=0.5, max_aspect=2.0
-):
+    geom: shapely.geometry.base.BaseGeometry, compactness_threshold: float=0.85, angle_tolerance: float=10, min_aspect: float=0.5, max_aspect: float=2.0
+) -> bool:
     """
     Determine if a geometry is approximately triangular based on compactness,
     hull vertex angles, and bounding box aspect ratio.
@@ -720,7 +721,7 @@ def detect_triangular_lots(
     return True
 
 
-def get_exterior_coords(geom):
+def get_exterior_coords(geom: Polygon) -> list | None:
     """Gets a list of all the exterior coordinates, regardless of whether the Geometry is a Polygon or MultiPolygon
 
     Parameters
@@ -743,13 +744,13 @@ def get_exterior_coords(geom):
 
 
 def identify_irregular_parcels(
-    gdf,
-    verbose=False,
-    tolerance=10,
-    complex_threshold=12,
-    rectangularity_threshold=0.75,
-    elongation_threshold=5,
-):
+    gdf: gpd.GeoDataFrame,
+    verbose: bool=False,
+    tolerance: int=10,
+    complex_threshold: int=12,
+    rectangularity_threshold: float=0.75,
+    elongation_threshold: float=5,
+) -> gpd.GeoDataFrame:
     """
     Detect and flag irregular parcel geometries based on shape metrics.
 
@@ -969,7 +970,7 @@ def geolocate_point_to_polygon(
     return df
 
 
-def _normalize_crs_value(crs_value):
+def _normalize_crs_value(crs_value) -> CRS:
     # Strings: catch OGC/URN/URL variants of CRS84 and map to EPSG:4326
     if isinstance(crs_value, str):
         s = crs_value.strip()

--- a/openavmkit/utilities/modeling.py
+++ b/openavmkit/utilities/modeling.py
@@ -382,7 +382,7 @@ class LandSLICEModel:
         location_factor: str = "location_factor",
         size_factor: str = "size_factor",
         prediction: str = "land_value"
-    ):
+    ) -> pd.DataFrame:
         for field in ["latitude", "longitude", self.size_field]:
             if field not in df:
                 raise ValueError(f"Required field {field} is missing from dataframe!")

--- a/openavmkit/utilities/plotting.py
+++ b/openavmkit/utilities/plotting.py
@@ -6,6 +6,7 @@ import numpy as np
 import colorsys
 import mpld3
 import statsmodels.api as sm
+from matplotlib.figure import Figure
 from matplotlib.ticker import FuncFormatter, ScalarFormatter
 from mpld3 import plugins
 
@@ -66,7 +67,7 @@ def plot_scatterplot(
     best_fit_line: bool = False,
     perfect_fit_line: bool = False,
     metadata_field: str = None,
-):
+) -> Figure:
     """Scatterplot with inline mpld3 tooltips showing df[metadata_field].
 
     Parameters
@@ -180,7 +181,7 @@ def plot_bar(
     title: str = "",
     out_file: str = None,
     style: dict = None,
-):
+) -> None:
     """
     Plots a simple bar graph
 
@@ -230,7 +231,7 @@ def plot_histogram_df(
     bins=500,
     x_lim=None,
     out_file: str = None,
-):
+) -> None:
     """
     Plots an overlaid histogram of one or more sets of values
 
@@ -294,7 +295,7 @@ def _plot_histogram_mult(
     bins: int | None = 500,
     x_lim=None,
     out_file: str | None = None,
-):
+) -> None:
     plt.close("all")
 
     plt.ticklabel_format(axis="x", style="plain")          # no sci‑notation
@@ -346,7 +347,7 @@ def _get_color_by(df: pd.DataFrame, style: dict):
 
 def _simple_ols(
     df_in: pd.DataFrame, ind_var: str, dep_var: str, intercept: bool = True
-):
+) -> dict:
 
     # check for nans/nulls in y:
     df = df_in[~df_in[dep_var].isna() & ~df_in[ind_var].isna()].copy()

--- a/openavmkit/utilities/settings.py
+++ b/openavmkit/utilities/settings.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 def load_settings(
     settings_file: str = "in/settings.json", settings_object: dict = None, error:bool=True, warning:bool=True
-):
+) -> dict | None:
     """
     Load settings file from disk
 
@@ -63,7 +63,7 @@ def load_settings(
     return settings
 
 
-def get_model_group(s: dict, key: str):
+def get_model_group(s: dict, key: str) -> dict:
     """
     Get a model group definition object from the settings dictionary
 
@@ -82,7 +82,7 @@ def get_model_group(s: dict, key: str):
     return s.get("modeling", {}).get("model_groups", {}).get(key, {})
 
 
-def get_valuation_date(s: dict):
+def get_valuation_date(s: dict) -> datetime:
     """
     Get the valuation date from the settings dictionary
 
@@ -153,7 +153,7 @@ def get_center(s: dict, gdf: gpd.GeoDataFrame = None) -> tuple[float, float]:
         raise ValueError("Could not find locality.center in settings!")
 
 
-def get_fields_land(s: dict, df: pd.DataFrame = None):
+def get_fields_land(s: dict, df: pd.DataFrame = None) -> dict:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to land.
 
@@ -187,7 +187,7 @@ def get_fields_land(s: dict, df: pd.DataFrame = None):
     return fields_land
 
 
-def get_fields_land_as_list(s: dict, df: pd.DataFrame = None):
+def get_fields_land_as_list(s: dict, df: pd.DataFrame = None) -> list[str]:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to land.
 
@@ -211,7 +211,7 @@ def get_fields_land_as_list(s: dict, df: pd.DataFrame = None):
     )
 
 
-def get_fields_impr(s: dict, df: pd.DataFrame = None):
+def get_fields_impr(s: dict, df: pd.DataFrame = None) -> dict:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to buildings/improvements.
 
@@ -234,7 +234,7 @@ def get_fields_impr(s: dict, df: pd.DataFrame = None):
     return _get_fields(s, "impr", df)
 
 
-def get_fields_impr_as_list(s: dict, df: pd.DataFrame = None):
+def get_fields_impr_as_list(s: dict, df: pd.DataFrame = None) -> list[str]:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to buildings/improvements.
 
@@ -258,7 +258,7 @@ def get_fields_impr_as_list(s: dict, df: pd.DataFrame = None):
     )
 
 
-def get_fields_other(s: dict, df: pd.DataFrame = None):
+def get_fields_other(s: dict, df: pd.DataFrame = None) -> dict:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to neither land nor
     buildings/improvements.
@@ -283,7 +283,7 @@ def get_fields_other(s: dict, df: pd.DataFrame = None):
     return _get_fields(s, "other", df)
 
 
-def get_fields_other_as_list(s: dict, df: pd.DataFrame = None):
+def get_fields_other_as_list(s: dict, df: pd.DataFrame = None) -> list[str]:
     """
     Get all fields in the given dataframe that are classified in settings as pertaining to neither land nor to
     buildings/improvements.
@@ -382,7 +382,7 @@ def get_fields_categorical(
     df: pd.DataFrame = None,
     include_boolean: bool = False,
     types: list[str] = None,
-):
+) -> list[str]:
     """
     Retrieve categorical field names based on settings and optional filters.
 
@@ -433,7 +433,7 @@ def get_fields_numeric(
     df: pd.DataFrame = None,
     include_boolean: bool = False,
     types: list[str] = None,
-):
+) -> list[str]:
     """
      Retrieve numeric field names based on settings and optional filters.
 
@@ -477,7 +477,7 @@ def get_fields_numeric(
     return nums
 
 
-def get_variable_interactions(entry: dict, settings: dict, df: pd.DataFrame = None):
+def get_variable_interactions(entry: dict, settings: dict, df: pd.DataFrame = None) -> dict:
     """
     Get variable interaction information from a dictionary object
 
@@ -492,7 +492,7 @@ def get_variable_interactions(entry: dict, settings: dict, df: pd.DataFrame = No
 
     Returns
     -------
-    dict | None
+    dict
         Interactions dictionary which maps field names to other field names, indicating variable interactions.
 
         Example:
@@ -521,7 +521,7 @@ def get_variable_interactions(entry: dict, settings: dict, df: pd.DataFrame = No
         return interactions.get("fields", {})
 
 
-def get_data_dictionary(settings: dict):
+def get_data_dictionary(settings: dict) -> dict:
     """
     Get the data dictionary object
 
@@ -568,7 +568,7 @@ def get_grouped_fields_from_data_dictionary(
     return result
 
 
-def get_model_group_ids(settings: dict, df: pd.DataFrame = None):
+def get_model_group_ids(settings: dict, df: pd.DataFrame = None) -> list[str]:
     """
     Get all model group ids specified in settings, in the preferred order specified by the user
 
@@ -607,7 +607,7 @@ def get_model_group_ids(settings: dict, df: pd.DataFrame = None):
     return ordered_ids
 
 
-def get_small_area_unit(settings: dict):
+def get_small_area_unit(settings: dict) -> str|None:
     """
     Get the designated "small" area unit (square feet or square meters)
 
@@ -618,8 +618,9 @@ def get_small_area_unit(settings: dict):
 
     Returns
     -------
-    str
+    str|None
         "sqft" if units are imperial and "sqm" if units are metric
+        None otherwise
     """
     base_units = settings.get("locality", {}).get("units", "imperial")
     if base_units == "imperial":
@@ -628,7 +629,7 @@ def get_small_area_unit(settings: dict):
         return "sqm"
 
 
-def get_large_area_unit(settings: dict):
+def get_large_area_unit(settings: dict)-> str|None:
     """
     Get the designated "large" area unit (acre or hectare)
 
@@ -639,8 +640,9 @@ def get_large_area_unit(settings: dict):
 
     Returns
     -------
-    str
+    str|None
         "acre" if units are imperial and "ha" if units are metric
+        None otherwise
     """
     base_units = settings.get("locality", {}).get("units", "imperial")
     if base_units == "imperial":
@@ -649,7 +651,7 @@ def get_large_area_unit(settings: dict):
         return "ha"  # hectare
 
 
-def get_short_distance_unit(settings: dict):
+def get_short_distance_unit(settings: dict) -> str|None:
     """
     Get the designated "short" distance unit (foot or meter)
 
@@ -660,8 +662,9 @@ def get_short_distance_unit(settings: dict):
 
     Returns
     -------
-    str
+    str|None
         "ft" if units are imperial and "m" if units are metric
+        None otherwise
     """
     base_units = settings.get("locality", {}).get("units", "imperial")
     if base_units == "imperial":
@@ -670,7 +673,7 @@ def get_short_distance_unit(settings: dict):
         return "m"
 
 
-def get_long_distance_unit(settings: dict):
+def get_long_distance_unit(settings: dict) -> str|None:
     """
     Get the designated "long" distance unit (mile or kilometer)
 
@@ -681,8 +684,9 @@ def get_long_distance_unit(settings: dict):
 
     Returns
     -------
-    str
+    str|None
         "mile" if units are imperial and "km" if units are metric
+        None otherwise
     """
     base_units = settings.get("locality", {}).get("units", "imperial")
     if base_units == "imperial":
@@ -765,7 +769,7 @@ def _get_unclassified_fields(s: dict, df: pd.DataFrame = None):
     return all
 
 
-def _get_fields(s: dict, type: str, df: pd.DataFrame = None):
+def _get_fields(s: dict, type: str, df: pd.DataFrame = None) -> dict:
     cats = s.get("field_classification", {}).get(type, {}).get("categorical", [])
     nums = s.get("field_classification", {}).get(type, {}).get("numeric", [])
     bools = s.get("field_classification", {}).get(type, {}).get("boolean", [])
@@ -778,8 +782,8 @@ def _get_fields(s: dict, type: str, df: pd.DataFrame = None):
     return {"categorical": cats, "numeric": nums, "boolean": bools}
 
 
-def _get_base_dir(s: dict):
-    slug = s.get("locality", {}).get("slug", None)
+def _get_base_dir(s: dict) -> str:
+    slug: str|None = s.get("locality", {}).get("slug", None)
     if slug is None:
         raise ValueError("Could not find settings.locality.slug!")
     return slug
@@ -797,7 +801,7 @@ def _process_settings(settings: dict):
     return s
 
 
-def _remove_comments_from_settings(s: dict):
+def _remove_comments_from_settings(s: dict) -> dict:
     comment_token = "__"
     keys_to_remove = []
     for key in s:
@@ -811,7 +815,7 @@ def _remove_comments_from_settings(s: dict):
     return s
 
 
-def _replace_variables(settings: dict):
+def _replace_variables(settings: dict) -> dict:
 
     result = settings.copy()
     failsafe = 999
@@ -826,7 +830,7 @@ def _replace_variables(settings: dict):
 
 def _do_replace_variables(
     node: dict | list | str, settings: dict, var_token: str = "$$"
-):
+) -> tuple[dict|list|str, int]:
     # For each key-value pair, search for values that are strings prefixed with $$, and replace them accordingly
 
     changes = 0
@@ -907,7 +911,7 @@ def _load_settings_template():
     return settings
 
 
-def _is_key_in(object: dict, key: str):
+def _is_key_in(object: dict, key: str) -> tuple[bool, str]:
     flags = ["+", "!"]
     for flag in ["+", "!", ""]:
         if f"{flag}{key}" in object:
@@ -915,7 +919,7 @@ def _is_key_in(object: dict, key: str):
     return False, ""
 
 
-def _strip_flags(settings: dict | list):
+def _strip_flags(settings: dict | list) -> dict | list:
     flags = ["+", "!"]
 
     if isinstance(settings, list):
@@ -1080,7 +1084,7 @@ def _get_max_ratio_study_trim(settings: dict, model_group: str)->float:
 
 def _simulate_removed_buildings(
     df: pd.DataFrame, settings: dict, idx_vacant: pd.Series = None
-):
+) -> pd.DataFrame:
     """Simulate removed buildings by changing improvement fields to values that reflect
     the absence of a building.
 

--- a/openavmkit/utilities/stats.py
+++ b/openavmkit/utilities/stats.py
@@ -17,7 +17,7 @@ from openavmkit.utilities.data import div_series_z_safe
 from openavmkit.utilities.settings import get_fields_boolean, get_fields_categorical
 
 
-def calc_chds(df_in: pd.DataFrame, field_cluster: str, field_value: str):
+def calc_chds(df_in: pd.DataFrame, field_cluster: str, field_value: str) -> pd.Series:
     """Calculate the Coefficient of Horizontal Dispersion (CHD) for each cluster in a
     DataFrame.
 
@@ -358,7 +358,7 @@ def trim_outlier_ratios(
     ground_truth: np.ndarray,
     max_percent: float = 0.10,
     iqr_factor: float = 1.5
-) -> (np.ndarray, np.ndarray):
+) -> tuple[np.ndarray, np.ndarray]:
     
     ratios = div_series_z_safe(predictions, ground_truth).astype(float)
     trim_mask = trim_outliers_mask(ratios, max_percent, iqr_factor)


### PR DESCRIPTION
Mostly type annotations.
One rename because it's not good to name a variable the same thing as the type it represents.
Adjusted docstrings where necessary.