### PR TITLE
The deleted example failed because openavmkit doesn't expose utilites

### DIFF
--- a/docs/docs/the_basics.md
+++ b/docs/docs/the_basics.md
@@ -61,17 +61,7 @@ That will be sufficient to get the file to load, but you will want to consult th
 
 Here's how you can import and use the core modules directly in your own Python code.
 
-For instance, here's a simple example that demonstrates how to calculate the Coefficient of Dispersion (COD) for a list of ratios:
-
-```python
-import openavmkit
-
-ratios = [0.8, 0.9, 1.0, 1.1, 1.2]
-cod = openavmkit.utilities.stats.calc_cod(ratios)
-print(cod)
-```
-
-You can also specify the specific module you want to import:
+For instance, here's a simple example that demonstrates how to calculate the Coefficient of Dispersion (COD) for a list of ratios by importing a specific module:
 
 ```python
 from openavmkit.utilities import stats


### PR DESCRIPTION
The deleted example in the docs:

```
For instance, here's a simple example that demonstrates how to calculate the Coefficient of Dispersion (COD) for a list of ratios:

import openavmkit

ratios = [0.8, 0.9, 1.0, 1.1, 1.2]
cod = openavmkit.utilities.stats.calc_cod(ratios)
print(cod)
```
failed because openavmkit doesn't expose utilites… in its __init__.py, so I've removed it. I'm not sure if you want to change the repo so that this works instead.

I'm also unsure of how you want forks and PRs to work, so feel free to let me know.