### PR TITLE
Delete unused data that includes a large dataframe to save RAM

### DIFF
--- a/openavmkit/benchmark.py
+++ b/openavmkit/benchmark.py
@@ -3655,6 +3655,7 @@ def _run_models(
         verbose=True,
     )
     best_variables = var_recs["variables"]
+    del var_recs # Delete var_recs to drop the results dataframe it holds since we don't need it
 
     any_results = False
 


### PR DESCRIPTION
Delete var_recs after getting the best variables because it contains a very large dataframe inside it that we no longer need, and we need the RAM for headspace for large model runs.