### PR TITLE
Fix for when False fill flips the dtype to a string

### DIFF
--- a/openavmkit/cleaning.py
+++ b/openavmkit/cleaning.py
@@ -352,7 +352,10 @@ def _fill_thing(df: pd.DataFrame, field: str | dict, fill_method: str):
     elif fill_method == "none":
         df = _fill_with(df, field, "NONE")
     elif fill_method == "false":
-        df = _fill_with(df, field, False)
+        if "str" in str(df[field].dtype).lower():
+            df = _fill_with(df, field, "False")
+        else:
+            df = _fill_with(df, field, False)
     elif fill_method == "mode":
         modal_values = df[~df[field].isna()][field].mode()
         if len(modal_values) > 0:


### PR DESCRIPTION
Fix issue where partial fills with false cause the field to flip to a string, and subsequent fills fail.

Because we fill per model group, the first fill can occasionally leave the dataframe in a state where there are True, False, and an unknown value in the same column. Because that's not valid for a boolean, the dataframe shifts to a string, but when it does, subsequent fills fail because False is not a valid fill for a string, but "False" is.