### PR TITLE
Memory fix for shared universe and sales

### DIFF
--- a/openavmkit/modeling.py
+++ b/openavmkit/modeling.py
@@ -545,10 +545,6 @@ class DataSplit:
 
         self.settings = settings.copy()
 
-        # An *unmodified* copy of the original model group universe/sales, that will remain unmodified
-        self.df_universe_orig = df_universe.copy()
-        self.df_sales_orig = df_sales.copy()
-
         # The working copy of the model group universe, that *will* be modified
         self.df_universe = df_universe.copy()
 
@@ -641,8 +637,6 @@ class DataSplit:
         ds.model_group = self.model_group
         ds.df_sales = self.df_sales.copy()
         ds.df_universe = self.df_universe.copy()
-        ds.df_universe_orig = self.df_universe_orig.copy()
-        ds.df_sales_orig = self.df_sales_orig.copy()
         ds._df_sales = self._df_sales.copy()
         ds.df_train = self.df_train.copy()
         ds.df_test = self.df_test.copy()

--- a/openavmkit/synthetic/generate.py
+++ b/openavmkit/synthetic/generate.py
@@ -665,13 +665,13 @@ def run_one_trial(sup: SalesUniversePair, params: dict):
                     hedonic_results[model] = results
 
     all_results = MultiModelResults(
-        model_results=model_results, benchmark=_calc_benchmark(model_results)
+        model_results=model_results, benchmark=_calc_benchmark(model_results), df_univ=df_univ, df_sales=df_sales
     )
 
     all_hedonic_results = None
     if hedonic_results is not None:
         all_hedonic_results = MultiModelResults(
-            model_results=hedonic_results, benchmark=_calc_benchmark(hedonic_results)
+            model_results=hedonic_results, benchmark=_calc_benchmark(hedonic_results), df_univ=df_univ, df_sales=df_sales
         )
 
     return all_results, all_hedonic_results


### PR DESCRIPTION
Move df_sales_orig and df_univ_orig up to the multi model results to save a lot of memory