### PR TITLE
Add GPBoost model engine support

### DIFF
--- a/openavmkit/utilities/modeling.py
+++ b/openavmkit/utilities/modeling.py
@@ -528,6 +528,20 @@ class LightGBMModel:
         self.cat_data = cat_data
 
 
+class GPBoostModel:
+    """GPBoost Model
+
+    Attributes
+    ----------
+    booster: Booster
+        The trained GPBoost Booster model
+    cat_data: TreeBasedCategoricalData
+    """
+    def __init__(self, booster, cat_data):
+        self.booster = booster
+        self.cat_data = cat_data
+
+
 class XGBoostModel:
     """XGBoost Model
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ catboost==1.2.8
 numpy==2.3.5
 huggingface-hub==1.2.3
 lightgbm==4.6.0
+gpboost==1.1.9
 markdown==3.10
 mgwr==2.2.1
 optuna==4.6.0


### PR DESCRIPTION
### Motivation
- Provide GPBoost (gpb) as an alternative tree-based model engine to allow users to select it the same way as XGBoost/LightGBM/CatBoost. 
- Reuse the existing tree-model tuning, training, prediction and SHAP workflows so GPBoost integrates with the benchmark and SHAP tooling.

### Description
- Added `gpboost==1.1.9` to `requirements.txt` and imported `gpboost as gpb` where needed. 
- Added `GPBoostModel` wrapper in `openavmkit/utilities/modeling.py` and extended the `TreeBasedModel`/`PredictionModel` unions to include it. 
- Implemented Optuna tuning helpers `_tune_gpboost` and `_gpboost_rolling_origin_cv` in `openavmkit/tuning.py` following the LightGBM/CatBoost patterns. 
- Implemented `run_gpboost` and `predict_gpboost` in `openavmkit/modeling.py` using the GPBoost API (`gpb.Dataset`, `gpb.train`) and wired them into the model selection and prediction flow. 
- Integrated GPBoost into SHAP handling (`openavmkit/shap_analysis.py`) by treating GPBoost like LightGBM for native-contrib SHAP paths and updating the explainers accordingly. 
- Wired GPBoost into the benchmark orchestration (`openavmkit/benchmark.py`) so it can be selected in model configs and participates in auto-variable-reduction and SHAP logic.

### Testing
- No automated tests were executed as part of this change; no `pytest`/CI runs were invoked. 
- Static review: updated imports/usages compile-time checked locally by running repository file scans, and the repository changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972afa835108326b83672d58a546129)