### PR TITLE
Update data.py

### DIFF
--- a/openavmkit/data.py
+++ b/openavmkit/data.py
@@ -4375,7 +4375,7 @@ def _perform_canonical_split(
 
     # This is how many test sales we need
     test_set_count = np.ceil(len(df) * test_share).astype(int)
-    if len(df) <= 30:
+    if len(df_v) <= 15:
         test_set_count_v = np.ceil(len(df_v) * test_share).astype(int)
     else:
         test_set_count_v = max(15, np.ceil(len(df_v) * test_share).astype(int))


### PR DESCRIPTION
If there are less than 15 vacant sales, max(15, np.ceil(len(df_v) * test_share).astype(int)) will put all of the vacant sales in the test set, and we end up with no vacant sales in the training set. This results in failures downstream when running hedonic regressions.