### PR TITLE
build(nix): add initial flake.nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tests/cache/
 cache/
 
 out/
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750506804,
+        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "Flake for openavmkit";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        pyPkgs = pkgs.python311Packages;
+        version = if self ? shortRev then "0.0.0+" + self.shortRev else "0.0.0";
+
+        openavmkit = pyPkgs.buildPythonPackage {
+          pname = "openavmkit";
+          inherit version;
+          src = ./.;
+          format = "setuptools";
+
+          nativeBuildInputs = with pyPkgs; [
+            setuptools-scm
+          ];
+
+          # Ensure deterministic versioning in Nix builds when .git metadata is absent.
+          SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+          pythonImportsCheck = [ "openavmkit" ];
+          doCheck = false;
+        };
+      in {
+        packages.default = openavmkit;
+        packages.openavmkit = openavmkit;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ openavmkit ];
+          packages = with pkgs; [
+            python311
+            git
+            pre-commit
+          ];
+
+          shellHook = ''
+            echo "Welcome to the openavmkit dev shell!"
+            export PYTHONPATH=$PWD
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Adds Nix flake support to enable reproducible builds and a consistent dev shell.

Tested the following:

`nix develop -c python -c "import openavmkit; print(openavmkit.__file__)"`

> Welcome to the openavmkit dev shell!
> ~/openavmkit/openavmkit/__init__.py

