### PR TITLE
Fix ArrowNotImplementedError in SalesScrutinyStudy with pyarrow >= 22

### DIFF
--- a/openavmkit/sales_scrutiny_study.py
+++ b/openavmkit/sales_scrutiny_study.py
@@ -111,8 +111,8 @@ class SalesScrutinyStudy:
         for key in stuff:
             df = stuff[key]
             df, cluster_fields = _mark_sales_scrutiny_clusters(df, settings)
-            df["ss_id"] = df["ss_id"].astype(str)
-            df["ss_id"] = df["model_group"] + "_" + key + "_" + df["ss_id"]
+            df["ss_id"] = df["ss_id"].astype(object).fillna("").astype(str)
+            df["ss_id"] = df["model_group"].astype(object).astype(str) + "_" + key + "_" + df["ss_id"]
             per_area = ""
             denominator = ""
             if key == "i":


### PR DESCRIPTION
## Summary

When a DataFrame column has Arrow `null` dtype (all-null values with no
inferred type), calling `.astype(str)` does not reliably convert it to
a string dtype in newer pyarrow/pandas combinations (observed with
pyarrow 22 + pandas 2.3). Subsequent string concatenation with a
`large_string`-typed column then raises:

    ArrowNotImplementedError: Function 'binary_join_element_wise' has no
    kernel matching input types (null, large_string, large_string)

This crashes `SalesScrutinyStudy.__init__` for any model group.

## Fix

Go through Python object dtype first (`.astype(object)`) before
`.astype(str)` on both `ss_id` and `model_group`, bypassing the Arrow
backend for this string concatenation.

## Reproduction

Install openavmkit with pyarrow >= 22 and pandas >= 2.3, then run
the sales scrutiny step on any locality. The crash occurs in
`SalesScrutinyStudy.__init__` at the `ss_id` construction lines.
