### PR TITLE
fix: impute NaN before variable-selection steps in stats.py

### DIFF
--- a/openavmkit/utilities/stats.py
+++ b/openavmkit/utilities/stats.py
@@ -1044,6 +1044,19 @@ def calc_elastic_net_regularization(
 
     X = X.copy()
 
+    # Impute NaN with column medians before standardization.
+    # ElasticNet (sklearn) does not accept NaN natively; median imputation is a neutral
+    # choice for this variable-selection pre-pass — LightGBM training still sees real NaN.
+    if X.isnull().values.any():
+        import warnings
+        warnings.warn(
+            f"calc_elastic_net_regularization: NaN detected in "
+            f"{list(X.columns[X.isnull().any()])}. "
+            "Imputing with column medians for the ElasticNet variable-selection step only.",
+            UserWarning,
+        )
+        X = X.fillna(X.median(numeric_only=True))
+
     # Standardize the features
     scaler = StandardScaler()
     X_scaled = scaler.fit_transform(X)
@@ -1195,9 +1208,22 @@ def calc_p_values_recursive_drop(
     """
 
     X = X.copy()
+
+    # Impute NaN with column medians — statsmodels OLS does not accept NaN natively.
+    # This is only for the p-value variable-selection pre-pass; LightGBM training sees real NaN.
+    if X.isnull().values.any():
+        import warnings
+        warnings.warn(
+            f"calc_p_values_recursive_drop: NaN detected in "
+            f"{list(X.columns[X.isnull().any()])}. "
+            "Imputing with column medians for the OLS variable-selection step only.",
+            UserWarning,
+        )
+        X = X.fillna(X.median(numeric_only=True))
+
     X = sm.add_constant(X, has_constant='add')
     X = X.astype(np.float64)
-    
+
     model = None
     try:
         model = sm.OLS(y, X).fit()
@@ -1287,6 +1313,19 @@ def calc_t_values_recursive_drop(
     """
 
     X = X.copy()
+
+    # Impute NaN with column medians — statsmodels OLS does not accept NaN natively.
+    # This is only for the t-value variable-selection pre-pass; LightGBM training sees real NaN.
+    if X.isnull().values.any():
+        import warnings
+        warnings.warn(
+            f"calc_t_values_recursive_drop: NaN detected in "
+            f"{list(X.columns[X.isnull().any()])}. "
+            "Imputing with column medians for the OLS variable-selection step only.",
+            UserWarning,
+        )
+        X = X.fillna(X.median(numeric_only=True))
+
     X = sm.add_constant(X, has_constant='add')
     X = X.astype(np.float64)
 
@@ -1395,6 +1434,19 @@ def calc_vif_recursive_drop(
         If no columns remain for VIF calculation.
     """
     X = X.copy()
+
+    # Impute NaN with column medians — VIF (OLS-based) does not accept NaN natively.
+    # This is only for the VIF variable-selection pre-pass; LightGBM training sees real NaN.
+    if X.isnull().values.any():
+        import warnings
+        warnings.warn(
+            f"calc_vif_recursive_drop: NaN detected in "
+            f"{list(X.columns[X.isnull().any()])}. "
+            "Imputing with column medians for the VIF variable-selection step only.",
+            UserWarning,
+        )
+        X = X.fillna(X.median(numeric_only=True))
+
     X = X.astype(np.float64)
 
     # Get boolean and categorical variables from settings if provided


### PR DESCRIPTION
## Problem

sklearn (`ElasticNet`) and statsmodels (OLS/VIF) raise errors when input features contain `NaN` values. This is triggered when a dataset uses LightGBM native NaN-handling -- e.g. sparse binary indicators like `has_garage` where `NaN` means "not recorded" -- and the variable-selection pre-pass runs before LightGBM training.

Errors seen:
- `ValueError: Input X contains NaN` (ElasticNet / sklearn)
- `MissingDataError: exog contains inf or nans` (statsmodels OLS)

## Fix

Add median imputation of `NaN` to the top of each of the four variable-selection functions:
- `calc_elastic_net_regularization`
- `calc_p_values_recursive_drop`
- `calc_t_values_recursive_drop`
- `calc_vif_recursive_drop`

Imputation is scoped to these pre-passes only: LightGBM training still receives the real `NaN` values and handles them natively at each split. A `UserWarning` is emitted listing the affected columns. Median imputation is a neutral choice for a variable-selection screen and does not bias which variables survive the screen.