### PR TITLE
fix: guard against n_splits > n_samples in rolling-origin CV

### DIFF
--- a/openavmkit/tuning.py
+++ b/openavmkit/tuning.py
@@ -485,6 +485,16 @@ def _catboost_rolling_origin_cv(
 
 
 def _lightgbm_rolling_origin_cv(X, y, params, n_splits=5, random_state=42, cat_vars=None):
+    n_samples = len(X)
+    n_splits = min(n_splits, n_samples)
+    if n_splits < 2:
+        import warnings
+        warnings.warn(
+            f"Not enough samples ({n_samples}) for cross-validation with n_splits={n_splits}. "
+            "Returning penalty MAPE of 1.0.",
+            UserWarning,
+        )
+        return 1.0
     kf = KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
     mape_scores = []
 


### PR DESCRIPTION
## Problem

`_lightgbm_rolling_origin_cv` crashes when `n_splits` exceeds the number of samples in the dataset. This happens with small model groups (e.g. a locality with very few sales in a given segment).

## Fix

Clamp `n_splits` to `n_samples` at the top of the function. If the clamped value is less than 2 (not enough for CV), emit a `UserWarning` and return a penalty MAPE of 1.0 rather than crashing.