### PR TITLE
fix: guard against all-NA scores in calc_correlations

### DIFF
--- a/openavmkit/tuning.py
+++ b/openavmkit/tuning.py
@@ -485,6 +485,16 @@ def _catboost_rolling_origin_cv(
 
 
 def _lightgbm_rolling_origin_cv(X, y, params, n_splits=5, random_state=42, cat_vars=None):
+    n_samples = len(X)
+    n_splits = min(n_splits, n_samples)
+    if n_splits < 2:
+        import warnings
+        warnings.warn(
+            f"Not enough samples ({n_samples}) for cross-validation with n_splits={n_splits}. "
+            "Returning penalty MAPE of 1.0.",
+            UserWarning,
+        )
+        return 1.0
     kf = KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
     mape_scores = []
 

--- a/openavmkit/utilities/stats.py
+++ b/openavmkit/utilities/stats.py
@@ -713,6 +713,9 @@ def calc_correlations(
 
         score = strength * clarity * clarity
 
+        # Guard against all-NA scores (too few samples to compute correlations)
+        if score.isna().all():
+            break
         min_score_idx = score.idxmin()
         try:
             min_score = score[min_score_idx]


### PR DESCRIPTION
## Problem

`calc_correlations` crashes with a `KeyError` or `ValueError` on `.idxmin()` when the computed `score` Series is all-NA. This occurs when there are too few samples to compute meaningful correlations (e.g. very small model groups or sparse data).

## Fix

Add an early `break` when `score.isna().all()` is detected, exiting the variable-dropping loop gracefully instead of crashing.

Note: this branch also includes the fix from #315 (`fix/tuning-min-samples-cv`), on which it stacks.