### PR TITLE
fix(tuning): cap LightGBM search space for thin datasets to prevent memorisation

### DIFF
--- a/openavmkit/tuning.py
+++ b/openavmkit/tuning.py
@@ -121,6 +121,20 @@ def _tune_lightgbm(
         dict: Best hyperparameters found by Optuna.
     """
 
+    # Bound search space by training-fold size to prevent memorisation on thin datasets.
+    # Each CV fold trains on roughly (n_splits-1)/n_splits of the data.
+    n_train_per_fold = int(len(X) * (n_splits - 1) / n_splits)
+    # num_leaves: cap at n_train_per_fold // 4 so each leaf covers ~4+ samples on average.
+    # This prevents the tuner from selecting thousands of leaves from a few hundred rows.
+    max_num_leaves = max(8, min(2048, n_train_per_fold // 4))
+    # min_data_in_leaf: upper bound must not exceed training fold size or every split is illegal.
+    max_min_data_in_leaf = max(2, min(500, n_train_per_fold // 4))
+    if verbose and max_num_leaves < 64:
+        print(
+            f"  [tune_lightgbm] thin dataset (n_train_per_fold={n_train_per_fold}): "
+            f"num_leaves capped at {max_num_leaves}, min_data_in_leaf capped at {max_min_data_in_leaf}"
+        )
+
     def objective(trial):
         """Objective function for Optuna to optimize LightGBM hyperparameters."""
         params = {
@@ -132,12 +146,12 @@ def _tune_lightgbm(
                 "learning_rate", 0.0001, 0.1, log=True
             ),
             "max_bin": trial.suggest_int("max_bin", 64, 1024),
-            "num_leaves": trial.suggest_int("num_leaves", 64, 2048),
+            "num_leaves": trial.suggest_int("num_leaves", min(64, max_num_leaves), max_num_leaves),
             "max_depth": trial.suggest_int("max_depth", 5, 15),
             "min_gain_to_split": trial.suggest_float(
                 "min_gain_to_split", 1e-4, 50, log=True
             ),
-            "min_data_in_leaf": trial.suggest_int("min_data_in_leaf", 20, 500),
+            "min_data_in_leaf": trial.suggest_int("min_data_in_leaf", min(20, max_min_data_in_leaf), max_min_data_in_leaf),
             "feature_fraction": trial.suggest_float(
                 "feature_fraction", 0.4, 0.9, log=False
             ),


### PR DESCRIPTION
## Problem

When a model group has very few training samples (e.g. <200), the Optuna tuner can select `num_leaves` values in the thousands. With ~101 training samples and `num_leaves=1514`, LightGBM effectively memorises the training folds — CV MAPE looks fine because the model can overfit each fold's tiny training set, but out-of-sample performance collapses.

Concrete example from Philadelphia AVM work: `residential_mf_large` has ~101 training sales. The tuner found `num_leaves=1514`, which degraded the ratio-study COD from ~40 to ~55 (IAAO standard ≤ 20 for residential). Manually fixing `num_leaves=15` recovered COD to ~40.

The same issue can affect `min_data_in_leaf`: with a range of `[20, 500]`, the upper bound can exceed the entire training fold size, making all splits illegal on the validation side.

## Fix

Before constructing the Optuna search space, compute the approximate training-fold size:

```python
n_train_per_fold = int(len(X) * (n_splits - 1) / n_splits)
max_num_leaves = max(8, min(2048, n_train_per_fold // 4))
max_min_data_in_leaf = max(2, min(500, n_train_per_fold // 4))
```

The `// 4` rule means each leaf covers at least ~4 samples on average — a conservative but reasonable floor for a regression tree. Both upper bounds are clamped to the original maximums (2048 and 500), so **large datasets are unaffected**.

A diagnostic `print` is emitted under `verbose=True` when the cap takes effect.

## Behaviour at key dataset sizes

| n (total) | n_train_per_fold (k=5) | max_num_leaves | max_min_data_in_leaf |
|---|---|---|---|
| 101 | 80 | 20 | 20 |
| 300 | 240 | 60 | 60 |
| 500 | 400 | 100 | 100 |
| 2000 | 1600 | 400 | 400 |
| 10000+ | 8000+ | 2000 → clamped to 2048 | 500 |

For n ≥ ~2560 the `num_leaves` cap has no effect (reaches the original 2048 ceiling). For n ≥ ~2000 the `min_data_in_leaf` cap reaches 500 (original ceiling).

## Test plan

- [ ] Verify existing tests pass (no breakage on normal-sized datasets)
- [ ] Smoke-test with a thin group (n < 200): confirm `num_leaves` in saved params is ≤ `n // 5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)