### PR TITLE
Fix MissingDataError in multi_mra when features contain NaN

### DIFF
--- a/openavmkit/modeling.py
+++ b/openavmkit/modeling.py
@@ -2039,6 +2039,17 @@ def _run_multi_mra(
 
     has_const = "const" in X_train
 
+    # Impute NaN with training-set column medians and propagate to all splits.
+    # Real-world property data routinely has missing values in features like
+    # parking spaces, garage counts, etc.  statsmodels OLS raises
+    # MissingDataError on any NaN in exog, so we guard here using the same
+    # median-imputation pattern applied elsewhere in the codebase.
+    col_medians = X_train.median()
+    X_train = X_train.fillna(col_medians)
+    ds_prepped.X_test = ds_prepped.X_test.fillna(col_medians)
+    ds_prepped.X_sales = ds_prepped.X_sales.fillna(col_medians)
+    ds_prepped.X_univ = ds_prepped.X_univ.fillna(col_medians)
+
     # ------------------------
     # Global OLS (fallback)
     # ------------------------

--- a/openavmkit/modeling.py
+++ b/openavmkit/modeling.py
@@ -2039,16 +2039,19 @@ def _run_multi_mra(
 
     has_const = "const" in X_train
 
-    # Impute NaN with training-set column medians and propagate to all splits.
-    # Real-world property data routinely has missing values in features like
-    # parking spaces, garage counts, etc.  statsmodels OLS raises
-    # MissingDataError on any NaN in exog, so we guard here using the same
-    # median-imputation pattern applied elsewhere in the codebase.
-    col_medians = X_train.median()
+    # Impute NaN/inf with training-set column medians and propagate to all splits.
+    # Real-world property data routinely has missing values (parking spaces,
+    # garage counts, etc.) and derived features can produce inf (e.g. FAR when
+    # land_area=0).  statsmodels OLS raises MissingDataError on any NaN or inf
+    # in exog, so we replace inf→NaN first, then median-impute.  Columns that
+    # are entirely NaN (no finite training values) fall back to 0.
+    # This is the same guard pattern used in utilities/stats.py.
+    X_train = X_train.replace([np.inf, -np.inf], np.nan)
+    col_medians = X_train.median().fillna(0.0)
     X_train = X_train.fillna(col_medians)
-    ds_prepped.X_test = ds_prepped.X_test.fillna(col_medians)
-    ds_prepped.X_sales = ds_prepped.X_sales.fillna(col_medians)
-    ds_prepped.X_univ = ds_prepped.X_univ.fillna(col_medians)
+    ds_prepped.X_test = ds_prepped.X_test.replace([np.inf, -np.inf], np.nan).fillna(col_medians)
+    ds_prepped.X_sales = ds_prepped.X_sales.replace([np.inf, -np.inf], np.nan).fillna(col_medians)
+    ds_prepped.X_univ = ds_prepped.X_univ.replace([np.inf, -np.inf], np.nan).fillna(col_medians)
 
     # ------------------------
     # Global OLS (fallback)


### PR DESCRIPTION
## Problem

`run_multi_mra` / `_run_multi_mra` crashes with:

```
statsmodels.tools.sm_exceptions.MissingDataError: exog contains inf or nans
```

when any feature in `ind_vars` has `NaN` values. This is common with real-world property data — fields like `bldg_parking_spaces`, `bldg_has_garage`, `bldg_central_air`, etc. are sparsely recorded by assessors and arrive as `NaN` after the `astype(float)` conversion on line 1940.

## Root cause

`_run_multi_mra` one-hot encodes categoricals and calls `astype(float)`, which preserves `NaN` from nullable `Float64` columns as `float64` NaN. There is no imputation step before `sm.OLS(y_train, X_train).fit()`, so statsmodels raises immediately.

## Fix

Impute `NaN` with training-set column medians immediately before the global OLS fit, and propagate the same medians to `X_test`, `X_sales`, and `X_univ` so all splits are treated consistently:

```python
col_medians = X_train.median()
X_train = X_train.fillna(col_medians)
ds_prepped.X_test  = ds_prepped.X_test.fillna(col_medians)
ds_prepped.X_sales = ds_prepped.X_sales.fillna(col_medians)
ds_prepped.X_univ  = ds_prepped.X_univ.fillna(col_medians)
```

This is the same median-imputation pattern already applied in `utilities/stats.py` (`calc_elastic_net_regularization`, `calc_p_values_recursive_drop`, `calc_t_values_recursive_drop`, `calc_vif_recursive_drop`) and accepted upstream in PRs #313, #316, #318.

## Test plan

- [ ] Run `multi_mra` against a dataset with at least one feature containing `NaN` values — confirm it completes without `MissingDataError`
- [ ] Confirm predictions are produced for all rows (train, test, sales, universe)
- [ ] Confirm no change in behaviour when all features are fully populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)