### PR TITLE
Add racial composition (pct_minority) to census block-group enrichment

### DIFF
--- a/openavmkit/utilities/census.py
+++ b/openavmkit/utilities/census.py
@@ -66,7 +66,10 @@ class CensusService:
             "B19013_001E": "median_income",
             "B01003_001E": "total_population",
             "B25064_001E": "median_g_rent",
-            "B25058_001E": "median_c_rent"
+            "B25058_001E": "median_c_rent",
+            # B03002: Hispanic or Latino origin by race — used to compute pct_minority
+            "B03002_001E": "_race_total",
+            "B03002_003E": "_race_nh_white",
         }
     
     
@@ -129,6 +132,12 @@ class CensusService:
         df = df.rename(
             columns=map
         )
+
+        # Compute pct_minority from B03002 racial composition variables
+        if "_race_total" in df.columns and "_race_nh_white" in df.columns:
+            total = df["_race_total"].replace(0, float("nan"))
+            df["pct_minority"] = 1.0 - (df["_race_nh_white"] / total)
+            df = df.drop(columns=["_race_total", "_race_nh_white"])
 
         # Create GEOID for block groups (state+county+tract+block group)
         df["state_fips"] = df["state"]


### PR DESCRIPTION
## Summary

Fetches ACS B03002 (Hispanic or Latino origin by race) alongside the existing block-group variables and computes a derived `pct_minority` field:

```
pct_minority = 1 − (B03002_003E / B03002_001E)
             = 1 − (Not Hispanic or Latino, White alone / Total)
```

The two raw B03002 columns are dropped after the computation — only `pct_minority` is exposed in the enriched parcel data.

## Why

[IAAO Standard on Mass Appraisal of Real Property (2017)](https://www.iaao.org/) §7.3 prohibits variables that produce racially discriminatory *outcomes*. The recommended compliance check is a ratio study stratified by neighborhood racial composition — confirming that assessment ratios don't vary systematically between predominantly-minority and predominantly-white block groups. Until now, that breakdown required users to fetch and join B03002 manually. With this change it's available automatically once census enrichment is enabled.

This is particularly useful when `median_income`, `pct_owner_occupied`, or similar demographic predictors are included in model features, since those variables can correlate with racial composition in segregated geographies.

## Usage

After this change, `pct_minority` is enriched onto the parcel universe. To add it to a ratio study breakdown, add to `settings.json`:

```json
"ratio_study": {
  "breakdowns": [
    {"by": "pct_minority", "quantiles": 5}
  ]
}
```

## Notes

- Backwards compatible: existing behavior is unchanged; `pct_minority` is simply a new column in the enriched output.
- Division-by-zero guarded: `race_total = 0` is replaced with `NaN` before division.
- The ACS 5-year estimates for B03002 are available for all US counties, so this works for any jurisdiction that already uses census enrichment.