### PR TITLE
Fix clear_cache() malformed .cols/.rows paths

### DIFF
--- a/openavmkit/utilities/cache.py
+++ b/openavmkit/utilities/cache.py
@@ -157,10 +157,10 @@ def clear_cache(filename: str, filetype: str) -> None:
     path = f"cache/{filename}"
     if os.path.exists(f"{path}.{ext}"):
         os.remove(f"{path}.{ext}")
-    if os.path.exists(f"{path}.cols{ext}"):
-        os.remove(f"{path}..cols.{ext}")
-    if os.path.exists(f"{path}.rows{ext}"):
-        os.remove(f"{path}.rows{ext}")
+    if os.path.exists(f"{path}.cols.{ext}"):
+        os.remove(f"{path}.cols.{ext}")
+    if os.path.exists(f"{path}.rows.{ext}"):
+        os.remove(f"{path}.rows.{ext}")
     if os.path.exists(f"{path}.signature.json"):
         os.remove(f"{path}.signature.json")
     if os.path.exists(f"{path}.cols.signature.json"):

--- a/tests/test_clear_cache_paths.py
+++ b/tests/test_clear_cache_paths.py
@@ -1,0 +1,32 @@
+import os
+
+from openavmkit.utilities.cache import clear_cache
+
+
+def test_clear_cache_removes_cols_and_rows(tmp_path, monkeypatch):
+    """clear_cache must remove the .cols / .rows fragments and their signatures.
+
+    Regression test: the path templates for the .cols/.rows data fragments were
+    malformed (missing dot in the existence check, double dot in the removal),
+    so clear_cache silently left the large .cols.parquet column-diff caches on
+    disk. Recreate every artifact a "df" cache entry produces and assert a clean
+    sweep.
+    """
+    monkeypatch.chdir(tmp_path)
+    os.makedirs("cache", exist_ok=True)
+
+    artifacts = [
+        "foo.parquet",
+        "foo.cols.parquet",
+        "foo.rows.parquet",
+        "foo.signature.json",
+        "foo.cols.signature.json",
+        "foo.rows.signature.json",
+    ]
+    for name in artifacts:
+        open(os.path.join("cache", name), "w").close()
+
+    clear_cache("foo", "df")
+
+    for name in artifacts:
+        assert not os.path.exists(os.path.join("cache", name)), f"{name} was not removed"


### PR DESCRIPTION
`clear_cache()` built the column/row fragment paths as `f"{path}.cols{ext}"` (missing the dot before the extension) for the existence check and `f"{path}..cols.{ext}"` (double dot) for removal — so the existence check never matched and the large `.cols.parquet` / `.rows.parquet` column-diff caches were silently left on disk. This uses the correct `{path}.cols.{ext}` / `{path}.rows.{ext}` templates.

Adds a regression test (`tests/test_clear_cache_paths.py`) that creates the full cache artifact set and asserts a clean sweep.