### PR TITLE
Capture waterway linestrings in the OSM rivers query

### DIFF
--- a/openavmkit/utilities/openstreetmap.py
+++ b/openavmkit/utilities/openstreetmap.py
@@ -80,7 +80,11 @@ class OpenStreetMapService:
             }
         elif thing == "rivers":
             return {
-                "water": ["river", "stream"]
+                # "water" tags polygon water *areas*; "waterway" tags the
+                # linestring river/stream features (how rivers are commonly
+                # mapped in OSM). Both are needed for full river coverage.
+                "water": ["river", "stream"],
+                "waterway": ["river", "stream"]
             }
         elif thing == "water":
             return {

--- a/tests/test_osm_rivers_tags.py
+++ b/tests/test_osm_rivers_tags.py
@@ -1,0 +1,12 @@
+from openavmkit.utilities.openstreetmap import OpenStreetMapService
+
+
+def test_rivers_query_includes_waterway_linestrings():
+    tags = OpenStreetMapService()._get_tags("rivers")
+    # waterway linestrings (the added coverage) — how rivers/streams are
+    # commonly mapped in OSM
+    assert "waterway" in tags
+    assert "river" in tags["waterway"]
+    assert "stream" in tags["waterway"]
+    # original polygon "water" coverage retained
+    assert "water" in tags


### PR DESCRIPTION
The built-in `rivers` query only matched polygon `water` areas (`water=river/stream`). Rivers and streams mapped as `waterway` *linestrings* — how rivers are commonly represented in OSM — were missed, so proximity-to-rivers enrichment under-counted them. This adds the `waterway` river/stream tags. Additive; no existing behavior removed.

Adds a test asserting the `rivers` tag set includes `waterway`.