### PR TITLE
Fix calc_prb: return the PRB slope instead of the intercept

### DIFF
--- a/openavmkit/utilities/stats.py
+++ b/openavmkit/utilities/stats.py
@@ -583,12 +583,12 @@ def calc_prb(
         model = sm.OLS(left, right).fit()
 
     # Guard against degenerate fit (rare but better to be explicit)
-    if model.df_resid <= 0 or not np.isfinite(model.params[0]):
+    if model.df_resid <= 0 or not np.isfinite(model.params[1]):
         return np.nan, np.nan, np.nan
 
-    prb = float(model.params[0])
+    prb = float(model.params[1])
     prb_lower, prb_upper = (
-        model.conf_int(alpha=1.0 - confidence_interval)[0].tolist()
+        model.conf_int(alpha=1.0 - confidence_interval)[1].tolist()
     )
 
     return prb, prb_lower, prb_upper

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -38,3 +38,30 @@ def test_cod_bootstrap():
   print("***")
 
   assert objects_are_equal(results, expected)
+
+def test_calc_prb_returns_slope():
+  import numpy as np
+  import statsmodels.api as sm
+  from openavmkit.utilities.stats import calc_prb
+
+  n = 500
+  truth = np.linspace(100_000, 1_000_000, n)
+  rank = np.linspace(0.0, 1.0, n)
+  preds = truth * (0.9 + 0.2 * rank)  # ratios rise with parcel value
+
+  prb, lo, hi = calc_prb(preds, truth)
+
+  # fit the identically transformed regression by hand
+  ratios = preds / truth
+  med = np.median(ratios)
+  left = (ratios - med) / med
+  right = sm.add_constant(np.log2(preds / med + truth), has_constant="add")
+  slope = sm.OLS(left, right).fit().params[1]
+
+  assert abs(prb - slope) < 1e-9
+  assert prb > 0
+  assert lo <= prb <= hi
+
+  # unbiased control: a flat multiplier of ground truth gives PRB near zero
+  prb0, _, _ = calc_prb(truth * 0.95, truth)
+  assert abs(prb0) < 1e-6


### PR DESCRIPTION
## What was wrong

In `openavmkit/utilities/stats.py`, `calc_prb` builds the PRB regression with
`sm.add_constant(right, has_constant='add')` (line 579 at 7952236), which
prepends the constant column. So `model.params[0]` is the intercept and
`model.params[1]` is the PRB coefficient. The function reads index 0
throughout:

- line 586: the degenerate-fit guard checks `model.params[0]`
- line 589: `prb = float(model.params[0])`
- line 591: the confidence interval is taken from row 0

Every PRB value the library reports today is the regression intercept, which
carries no vertical-equity signal. The sign and magnitude are unrelated to
price-related bias.

## The change

Index 1 instead of index 0 in all three places (guard, coefficient,
confidence interval). Three lines, no behavior change elsewhere.

One related note for reviewers: the value proxy on line 578 omits the 0.5
scaling from the IAAO formulation. Under log2 that only shifts the intercept,
not the slope, so it does not affect this fix and is left untouched here.

## What changes downstream

All reported PRB numbers change, including in `ratio_study.py` (lines
125-126), `vertical_equity_study.py` (line 111), and `modeling.py` (line
263). That is the point of the fix: the previous numbers were intercepts.
Anyone tracking PRB across runs will see a step change after upgrading.

## Verification

A test is included (`tests/test_stats.py`). It builds a synthetic ratio set
with a known value-correlated bias (predictions overshoot high-value parcels
and undershoot low-value ones), fits the same transformed regression by hand
with `sm.OLS`, and asserts three things: `calc_prb` matches the hand-fit
`params[1]` to within float tolerance, the sign matches the injected bias
direction, and an unbiased control set (predictions equal to a constant
multiple of ground truth) yields a PRB near zero. At 7952236 the biased case
fails (the intercept comes back instead of the slope); with this change it
passes.

Fixes #370.