### PR TITLE
Fix inverted non-numeric >= and <= fallbacks in resolve_filter

### DIFF
--- a/openavmkit/filters.py
+++ b/openavmkit/filters.py
@@ -190,12 +190,12 @@ def resolve_filter(df: pd.DataFrame, f: list, rename_map: dict = None) -> pd.Ser
             if is_column_of_type(df, field, "number"):
                 return df[field].fillna(0).ge(value)
             else:
-                return df[field].le(value)
+                return df[field].ge(value)
         if operator == "<=":
             if is_column_of_type(df, field, "number"):
                 return df[field].fillna(0).le(value)
             else:
-                return df[field].ge(value)
+                return df[field].le(value)
         if operator == "==":
             return df[field].eq(value)
         if operator == "!=":

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -643,3 +643,23 @@ def test_filter_debug():
   assert lists_are_equal(results_sf_select_improved, ['165177'])
   assert lists_are_equal(results_sf_select_vacant, [])
 
+
+
+def test_string_ordered_comparisons():
+  import pandas as pd
+  from openavmkit.filters import resolve_filter
+
+  df = pd.DataFrame({"sale_date": ["2019-06-01", "2020-01-01", "2021-03-15"]})
+
+  ge = resolve_filter(df, [">=", "sale_date", "str:2020-01-01"])
+  assert list(df[ge]["sale_date"]) == ["2020-01-01", "2021-03-15"]
+
+  le = resolve_filter(df, ["<=", "sale_date", "str:2020-01-01"])
+  assert list(df[le]["sale_date"]) == ["2019-06-01", "2020-01-01"]
+
+  # > and < were already correct; control cases
+  gt = resolve_filter(df, [">", "sale_date", "str:2020-01-01"])
+  assert list(df[gt]["sale_date"]) == ["2021-03-15"]
+
+  lt = resolve_filter(df, ["<", "sale_date", "str:2020-01-01"])
+  assert list(df[lt]["sale_date"]) == ["2019-06-01"]


### PR DESCRIPTION
## What was wrong

In `openavmkit/filters.py` at 7952236, the non-numeric fallback branches for
`>=` and `<=` are swapped:

- line 193: `>=` on a non-numeric column returns `df[field].le(value)`
- line 198: `<=` on a non-numeric column returns `df[field].ge(value)`

The `>` and `<` branches just above (lines 183, 188) are correct, which
points to a copy-paste swap. The effect is that any settings filter that
compares a string column with `>=` or `<=` (the common case being sale-date
thresholds like `[">=", "sale_date", "str:2020-01-01"]`) silently selects
the exact complement of the intended rows.

## The change

Swap them back: `>=` maps to `.ge(value)` and `<=` maps to `.le(value)`.
Two lines. Numeric columns are unaffected (they take the
`is_column_of_type` branch, which was already correct).

## What changes downstream

Filters on non-numeric columns using `>=` or `<=` start selecting the rows
they say they select. Any settings file that unknowingly relied on the
inverted behavior will flip, but that behavior contradicted both the
operator names and the numeric branch, so the previous results were wrong.

## Verification

A test is included (`tests/test_filters.py`). It builds a frame with a
string `sale_date` column spanning three dates and asserts that
`[">=", "sale_date", "str:<middle date>"]` selects the middle and later
rows and `["<=", ...]` selects the middle and earlier rows. Both assertions
fail at 7952236 and pass with this change.

Fixes #376.