### PR TITLE
Fill missing categoricals as UNKNOWN instead of the string "nan"

### DIFF
--- a/openavmkit/cleaning.py
+++ b/openavmkit/cleaning.py
@@ -745,8 +745,7 @@ def _fill_unknown_values(df, settings: dict):
     if cat_fields is not None:
         for field in cat_fields:
             if field in df:
-                df[field] = df[field].astype("str")
-                df[field] = df[field].fillna("UNKNOWN")
+                df[field] = df[field].astype("object").fillna("UNKNOWN").astype("str")
 
     if bool_fields is not None:
         for field in bool_fields:

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+
+from openavmkit.cleaning import _fill_unknown_values
+
+
+def test_residual_categorical_fill_uses_unknown_not_nan():
+  df = pd.DataFrame(
+    {
+      "key": ["a", "b", "c"],
+      "bldg_style": ["RAMBLER", np.nan, "SPLIT"],
+    }
+  )
+  settings = {
+    "field_classification": {
+      "impr": {"categorical": ["bldg_style"]}
+    }
+  }
+  out = _fill_unknown_values(df, settings)
+  values = set(out["bldg_style"].astype(str))
+  assert "UNKNOWN" in values
+  assert "nan" not in values
+  assert "<NA>" not in values


### PR DESCRIPTION
## What was wrong

In `openavmkit/cleaning.py`, `_fill_unknown_values` (lines 748-749 at
7952236) casts categorical fields to `str` before filling:

    df[field] = df[field].astype("str")
    df[field] = df[field].fillna("UNKNOWN")

`astype("str")` converts NaN to the literal string "nan" first, so the
`fillna` on the next line never finds anything to fill. Models end up with
a "nan" category instead of the intended "UNKNOWN".

## The change

Reorder so the fill happens while the nulls are still real:

    df[field] = df[field].astype("object").fillna("UNKNOWN").astype("str")

Going through `object` keeps NaN intact for the fill and also sidesteps the
categorical-dtype restriction on filling with an unseen category.

## What changes downstream

The category label for missing values changes from "nan" to "UNKNOWN", so
one-hot column names and tree categorical levels shift accordingly.
Refitting after upgrading will produce slightly different encodings than
cached models built against the "nan" label; model caches should be
invalidated once this lands.

## Verification

A test is included. It runs a frame containing NaN in a declared
categorical field through the fill step and asserts the result contains
"UNKNOWN" and no "nan" values. At 7952236 the "nan" assertion fails; with
this change it passes.

Fixes #377.